### PR TITLE
Added Bao and Staudt to list of reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   target-branch: dev
   reviewers:
   - t-ober
-  - sensarmad
+  - jo-bao
   - danielfeismann
   - sebastian-peter
+  - staudtMarius

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased/Snapshot]
 
+### Added
+- Added Bao and Staudt to the list of reviewers [#216](https://github.com/ie3-institute/simonaAPI/issues/216)
+
 ## [0.6.0] - 2024-12-02
 
 ### Added


### PR DESCRIPTION
This pull request includes changes to the list of reviewers in the `dependabot` configuration file and updates the `CHANGELOG.md` to reflect these changes.

Updates to reviewer list:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R15): Added `jo-bao` and `staudtMarius` to the list of reviewers and removed `sensarmad`.

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R11): Added an entry to reflect the addition of Bao and Staudt to the list of reviewers.